### PR TITLE
[Org README] Fix Help-wanted issues link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -41,6 +41,6 @@ Useful links for contributors:
 
 **Website available at:** [ScratchAddons.com](https://scratchaddons.com), [ScratchAddons.org](https://scratchaddons.org)
 
-**Relevant links:** [Website analytics](https://scratchaddons.com/analytics) | [Help-wanted issues](https://github.com/ScratchAddons/website-v2/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted)
+**Relevant links:** [Website analytics](https://scratchaddons.com/analytics) | [Help-wanted issues](https://github.com/ScratchAddons/website-v2/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 
 **Related GitHub repositories:** [website-i18n](https://github.com/ScratchAddons/website-i18n) | [website-v2-script](https://github.com/ScratchAddons/website-v2-script)


### PR DESCRIPTION
The search query was missing a ”, causing the search to return no results.

Problematic URL: https://github.com/ScratchAddons/website-v2/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted
Fixed URL: https://github.com/ScratchAddons/website-v2/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22